### PR TITLE
[RFR][MAJOR] Match one-parameter Bluebird 3.x spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![js-semistandard-style](https://cdn.rawgit.com/flet/semistandard/master/badge.svg)](https://github.com/Flet/semistandard)
 
-Wraps a synchronously executing function and returns a promise that resolves to its return value and rejects its exceptions. API-compatible with [Bluebird](https://github.com/petkaantonov/bluebird)'s `Promise.try`.
+Wraps a synchronously executing function and returns a promise that resolves to its return value and rejects its exceptions. API-compatible with [Bluebird](https://github.com/petkaantonov/bluebird)'s `Promise.try` ([API Reference](http://bluebirdjs.com/docs/api/promise.try.html)).
 
 Accepts an alternate Promise implementation as input if the environment doesn't natively support them.
 
@@ -22,17 +22,14 @@ promiseTry(function () {
 ## API
 
 ```js
-function promiseTry(fn, args, ctx, Promise)
+function promiseTry(fn, Promise)
 ```
 
-`fn` - a synchronously executed function that may return or throw synchronously. This will be wrapped and returned as a promise.
+`fn` - a synchronously executed function that may return or throw synchronously. This will be wrapped and returned as a promise.  If arguments or a context need to be
+applied to the function, use `fn.bind(ctx, arg1, arg2...)`:
 
-`args` - arguments to applied to the passed function. If not an array, it will be passed as a single argument to the function. If an array, it will be spread across the function's parameters.
+```js
+promiseTry(function (paramValue) { return paramValue * valueInThis }.bind(this, 5));
+```
 
-<small>I personally don't like this API since one could never achieve passing the function a single argument that is an array, but this is here for compatibility with bluebird. Instead, one could just use something like `.bind(null, [1, 2, 3])` when passing the function.</small>
-
-`ctx` - the context (`this`) to be used when the function is executed.
-
-<small>Again, one could just use `.bind(ctx)` on the original function</small>
-
-`Promise` an alternate Promise implementation to use (perhaps if a global one doesn't exist)
+`Promise` - an alternate Promise implementation to use (perhaps if a global one doesn't exist)

--- a/index.js
+++ b/index.js
@@ -1,10 +1,9 @@
-module.exports = function promiseTry (fn, args, ctx, Promise) {
+module.exports = function promiseTry (boundFn, Promise) {
   Promise = Promise || global.Promise;
 
   return new Promise(function (resolve, reject) {
     try {
-      var method = Array.isArray(args) ? 'apply' : 'call';
-      resolve(fn[method](ctx, args));
+      resolve(boundFn());
     } catch (e) {
       reject(e);
     }

--- a/test.js
+++ b/test.js
@@ -27,35 +27,6 @@ test('returns promise resolving with a successful return value', function (t) {
   });
 });
 
-test('calls with a given argument if not an array', function (t) {
-  return ptry(function (x) {
-    return x * x;
-  }, 5).then(function (res) {
-    t.equal(res, 25);
-  });
-});
-
-test('applies with a given argument if an array', function (t) {
-  return ptry(function (x, y) {
-    return x * y;
-  }, [5, 10]).then(function (res) {
-    t.equal(res, 50);
-  });
-});
-
-test('uses the provided context when executing the function', function (t) {
-  var ctx = {
-    x: 'hello ',
-    y: 'world'
-  };
-
-  return ptry(function () {
-    return this.x + this.y;
-  }, null, ctx).then(function (res) {
-    t.equal(res, 'hello world');
-  });
-});
-
 test('doesnt re-wrap promise-returning functions', function (t) {
   return ptry(function () {
     return Promise.resolve(5);
@@ -79,7 +50,7 @@ test('doesnt re-wrap thenable-returning functions', function (t) {
 test('uses user-provided Promise constructor if passed', function (t) {
   return ptry(function () {
     return 5;
-  }, null, null, Pinkie).then(function (res) {
+  }, Pinkie).then(function (res) {
     t.equal(res, 5);
   });
 });


### PR DESCRIPTION
Bluebird v3 only accepts one argument in Promise.try - the bound
function.  Any parameter/context assignment must be done on
the function itself before being passed into Promise.try.